### PR TITLE
Fix: make sure `spread` returns a thenable

### DIFF
--- a/dist/q-spread.js
+++ b/dist/q-spread.js
@@ -23,7 +23,7 @@
                             resolve.apply(void 0, data);
                         }
 
-                        promise.then(spread, reject);
+                        return promise.then(spread, reject);
                     };
 
                     return promise;

--- a/dist/q-spread.min.js
+++ b/dist/q-spread.min.js
@@ -1,1 +1,1 @@
-!function(n){"use strict";n.module("$q-spread",[]).config(["$provide",function(n){n.decorator("$q",["$delegate",function(n){var o=n.all;return n.all=function(n){var r=o(n);return r.spread=function(n,o){function t(o){n.apply(void 0,o)}r.then(t,o)},r},n}])}])}(window.angular);
+!function(n){"use strict";n.module("$q-spread",[]).config(["$provide",function(n){n.decorator("$q",["$delegate",function(n){var r=n.all;return n.all=function(n){var t=r(n);return t.spread=function(n,r){function e(r){n.apply(void 0,r)}return t.then(e,r)},t},n}])}])}(window.angular);

--- a/src/q-spread.js
+++ b/src/q-spread.js
@@ -23,7 +23,7 @@
                             resolve.apply(void 0, data);
                         }
 
-                        promise.then(spread, reject);
+                        return promise.then(spread, reject);
                     };
 
                     return promise;


### PR DESCRIPTION
Hello!

It seems reasonable that you should be able to continue chaining thenables after a .spread call, just as in Bluebird etc.

Thanks for the module!