### PR TITLE
Fixes missing `index.js`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+return require('./src/q-spread');


### PR DESCRIPTION
`package.json` specifies `index.js` for `main` - which does not exist, breaking my browserify build. This PR fixes it.